### PR TITLE
FIX: kit2fiff dev-head coregistration

### DIFF
--- a/mne/fiff/kit/kit.py
+++ b/mne/fiff/kit/kit.py
@@ -306,9 +306,8 @@ class RawKIT(Raw):
         coreg_data = coreg.coreg(mrk_fname=self.mrk_fname,
                                  elp_fname=self.elp_fname,
                                  hsp_fname=self.hsp_fname)
-        head_dev_t = fit_matched_pts(src_pts=coreg_data.elp_points,
-                                     tgt_pts=coreg_data.mrk_points)
-        dev_head_t = np.array(head_dev_t.I)
+        dev_head_t = fit_matched_pts(tgt_pts=coreg_data.mrk_points,
+                                     src_pts=coreg_data.elp_points)
         return dev_head_t, coreg_data.hsp_points
 
 def read_raw_kit(input_fname, sns_fname, hsp_fname, elp_fname, mrk_fname,

--- a/mne/transforms/coreg.py
+++ b/mne/transforms/coreg.py
@@ -23,7 +23,7 @@ def fit_matched_pts(src_pts, tgt_pts, params=False):
         Points to which the transform should be applied.
     tgt_pts : array, shape = (n, 3)
         Points to which src_pts should be fitted. Each point in tgt_pts should
-        correspond to the point in src_pts withthe same index.
+        correspond to the point in src_pts with the same index.
     params : bool
         Also return the estimated rotation and translation parameters.
 
@@ -38,15 +38,14 @@ def fit_matched_pts(src_pts, tgt_pts, params=False):
         The translation parameters in x, y, and z direction.
 
     """
+    print src_pts, tgt_pts
     def error(params):
         trans = dot(translation(*params[:3]), rotation(*params[3:]))
         est = apply_trans(trans, src_pts)
         return (tgt_pts - est).ravel()
 
     x0 = (0, 0, 0, 0, 0, 0)
-    x, info = leastsq(error, x0)
-    if info not in [1, 2, 3, 4]:
-        raise RuntimeError("Fit failed with code %r" % info)
+    x, _ = leastsq(error, x0)
 
     transl = x[:3]
     rot = x[3:]


### PR DESCRIPTION
`read_raw_kit` works again, just throws some warnings. Did you get the warnings apart from the `minpack` warning previously, or are they also introduced with the new coreg function?
