### PR TITLE
ENH fit_matched_pts: add tolerance parameter

### DIFF
--- a/mne/transforms/coreg.py
+++ b/mne/transforms/coreg.py
@@ -4,13 +4,14 @@
 #
 # License: BSD (3-clause)
 
+import numpy as np
 from numpy import dot
 from scipy.optimize import leastsq
 
 from .transforms import apply_trans, rotation, translation
 
 
-def fit_matched_pts(src_pts, tgt_pts, params=False):
+def fit_matched_pts(src_pts, tgt_pts, tol=None, params=False):
     """Find a transform that minimizes the squared distance between two
     matching sets of points.
 
@@ -24,6 +25,10 @@ def fit_matched_pts(src_pts, tgt_pts, params=False):
     tgt_pts : array, shape = (n, 3)
         Points to which src_pts should be fitted. Each point in tgt_pts should
         correspond to the point in src_pts with the same index.
+    tol : scalar | None
+        The error tolerance. If the distance between any of the matched points
+        exceeds this value in the solution, a RuntimeError is raised. With
+        None, no error check is performed.
     params : bool
         Also return the estimated rotation and translation parameters.
 
@@ -36,7 +41,6 @@ def fit_matched_pts(src_pts, tgt_pts, params=False):
         The rotation parameters around the x, y, and z axes (in radians).
     [translation : array, len = 3, optional]
         The translation parameters in x, y, and z direction.
-
     """
     def error(params):
         trans = dot(translation(*params[:3]), rotation(*params[3:]))
@@ -44,11 +48,19 @@ def fit_matched_pts(src_pts, tgt_pts, params=False):
         return (tgt_pts - est).ravel()
 
     x0 = (0, 0, 0, 0, 0, 0)
-    x, _ = leastsq(error, x0)
+    x, _, _, _, _ = leastsq(error, x0, full_output=True)
 
     transl = x[:3]
     rot = x[3:]
     trans = dot(translation(*transl), rotation(*rot))
+
+    # assess the error of the solution
+    if tol is not None:
+        est_pts = apply_trans(trans, src_pts)
+        err = np.sqrt(np.sum((est_pts - tgt_pts) ** 2, axis=1))
+        if np.any(err > tol):
+            raise RuntimeError("Error exceeds tolerance. Error = %r" % err)
+
     if params:
         return trans, rot, transl
     else:

--- a/mne/transforms/tests/test_coreg.py
+++ b/mne/transforms/tests/test_coreg.py
@@ -1,3 +1,4 @@
+from nose.tools import assert_raises
 import numpy as np
 from numpy.testing import assert_array_almost_equal
 
@@ -7,9 +8,13 @@ from mne.transforms.transforms import apply_trans, rotation, translation
 
 def test_fit_matched_pts():
     """Test fitting two matching sets of points"""
-    pts0 = np.random.normal(size=(5, 3))
+    src_pts = np.random.normal(size=(5, 3))
     trans0 = np.dot(translation(2, 65, 3), rotation(2, 6, 3))
-    pts1 = apply_trans(trans0, pts0)
-    trans = fit_matched_pts(pts1, pts0)
-    pts1t = apply_trans(trans, pts1)
-    assert_array_almost_equal(pts0, pts1t)
+    tgt_pts = apply_trans(trans0, src_pts)
+    trans = fit_matched_pts(tgt_pts, src_pts)
+    est_pts = apply_trans(trans, tgt_pts)
+    assert_array_almost_equal(src_pts, est_pts)
+
+    # test exceeding tolerance
+    src_pts[0, :] += 20
+    assert_raises(RuntimeError, fit_matched_pts, src_pts, tgt_pts, tol=10)


### PR DESCRIPTION
I added a tolerance parameter to the fit_matched_pts function, this gets rid of the warning during the tests. The default is to not check the error, but if you think that would be useful you could include the specification of the error tolerance in the conversion utility.
